### PR TITLE
Doc update: also need to install latex-xcolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ On Ubuntu you will have to install the following packages:
     texlive
     texlive-latex-extra
     texlive-math-extra
+    latex-xcolor
 
 You should also install:
 


### PR DESCRIPTION
Without installing latex-xcolor, on Linux Mint 17 (which is based on Ubuntu 14.04) the build of a basic .simplex file failed with an error from LaTeX saying the xcolor package was missing.
